### PR TITLE
 fix bug version

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -62,7 +62,6 @@ theme:
 
 # Plugins
 plugins:
-  - social
   - search:
       separator: '[\s\-,:!=\[\]()"/]+|(?!\b)(?=[A-Z][a-z])|\.(?!\d)|&[lg]t;'
   - mkdocstrings:
@@ -89,33 +88,56 @@ extra_javascript:
 extra_css:
   - stylesheets/extra.css
   - https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.16.7/katex.min.css
+  
 # Extensions
 markdown_extensions:
-  - pymdownx.highlight:
-      anchor_linenums: true
-  - pymdownx.inlinehilite
-  - pymdownx.snippets
+  - abbr
   - admonition
+  - attr_list
+  - def_list
+  - footnotes
+  - md_in_html
+  - toc:
+      permalink: true
   - pymdownx.arithmatex:
       generic: true
-  - footnotes
+  - pymdownx.betterem:
+      smart_enable: all
+  - pymdownx.caret
   - pymdownx.details
+  - pymdownx.emoji:
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+  - pymdownx.highlight:
+      anchor_linenums: true
+      line_spans: __span
+      pygments_lang_class: true
+  - pymdownx.inlinehilite
+  - pymdownx.keys
+  - pymdownx.magiclink:
+      normalize_issue_symbols: true
+      repo_url_shorthand: true
+      user: squidfunk
+      repo: mkdocs-material
+  - pymdownx.mark
+  - pymdownx.smartsymbols
+  - pymdownx.snippets:
+      auto_append:
+        - includes/mkdocs.md
   - pymdownx.superfences:
       custom_fences:
         - name: mermaid
           class: mermaid
-          format: !!python/name:pymdownx.superfences.fence_code_format    
+          format: !!python/name:pymdownx.superfences.fence_code_format
   - pymdownx.tabbed:
-      alternate_style: true 
+      alternate_style: true
+      combine_header_slug: true
       slugify: !!python/object/apply:pymdownx.slugs.slugify
         kwds:
           case: lower
-  - pymdownx.mark
-  - attr_list
-  - pymdownx.emoji:
-      emoji_index: !!python/name:materialx.emoji.twemoji
-      emoji_generator: !!python/name:materialx.emoji.to_svg
-  - md_in_html
+  - pymdownx.tasklist:
+      custom_checkbox: true
+  - pymdownx.tilde
 
 # Page tree
 nav:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-mkdocs-material==9.1.19
-pillow==9.5.0
-cairosvg==2.7.0
+mkdocs-material
+pillow
+cairosvg
 mkdocstrings[python]
 mkdocs-jupyter


### PR DESCRIPTION
The warning message you provided indicates a deprecation warning related to the Jupyter paths configuration. The warning suggests that Jupyter is migrating its paths to use the standard platformdirs library. To address this warning and view the appropriate new directories, you can follow the steps below:

1. Set the JUPYTER_PLATFORM_DIRS environment variable to 1. You can do this by running the following command in your terminal or command prompt:
```bash
export JUPYTER_PLATFORM_DIRS=1
```
Note: This command assumes you are using a Unix-like operating system. If you are using Windows, you can use the set command instead:
```bash
set JUPYTER_PLATFORM_DIRS=1
```
2. After setting the environment variable, run the following command to view the new Jupyter paths:
```bash
jupyter --paths
```
This command will display the new directories that Jupyter is using.

By following these steps, you should be able to address the deprecation warning and see the appropriate new directories for Jupyter.